### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "shim",
     "iisnode"
   ],
+  "files": ["index.js"],
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Prevents `.travis.yml` and `test.js` from being published to NPM.