### PR TITLE
chore: drop support for Node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 os:
   - linux
 node_js:
-  - "0.10"
   - "4"
   - "6"
-  - "node"
+  - "stable"


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node 0.10/0.12